### PR TITLE
feature: Use --skip by default to allow skipping report on pull requests CY-3472

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,5 +15,5 @@ do
     fi
 done
 
-bash <(curl -Ls https://coverage.codacy.com/get.sh) report $params --partial &&\
-bash <(curl -Ls https://coverage.codacy.com/get.sh) final
+bash <(curl -Ls https://coverage.codacy.com/get.sh) report --skip $params --partial &&\
+bash <(curl -Ls https://coverage.codacy.com/get.sh) final --skip


### PR DESCRIPTION
The rationale here is that if you use the action you are forced to add the token from your secrets.
Still it is a good default to skip CI on forks because you don't want to pass your secrets to forks.

**Explanation** 
We have a option in the binary to skip the coverage reporting when the token is not define.d
This is handy if you have a public repository. This because generally you don’t want to give your Codacy token to people.
So when you have a public repository you pass `--skip`  and if the token is not defined ( the secret has not been passed ) the coverage reporter process will just return 0 without sending anything.
Now, the action needs you to define the token as a mandatory parameter. So it can’t happen that you forget to add it.
But if someone forks your repository the CI will fail because they don’t have the secrets.