### PR TITLE
doc: Add links to instructions on how to obtain the API tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ jobs:
 
 Change these options in the workflow `.yml` file to meet your GitHub project needs:
 
-| Setting            | Description                                                                            | Default value                         |
+| Setting            | Description                                                                            | Recommended value                         |
 | ------------------ | -------------------------------------------------------------------------------------- | ------------------------------------- |
 | `api-token`        | [Account API token](https://docs.codacy.com/codacy-api/api-tokens/#account-api-tokens) | `${{ secrets.CODACY_API_TOKEN }}`     |
 | `project-token`    | [Project API token](https://docs.codacy.com/codacy-api/api-tokens/#project-api-tokens) | `${{ secrets.CODACY_PROJECT_TOKEN }}` |

--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ jobs:
 
 ## Workflow options
 
-Change these options in the workflow `.yml` file to meet your GitHub project needs.
+Change these options in the workflow `.yml` file to meet your GitHub project needs:
 
-| Setting            | Description                                      | Default value                         |
-| ------------------ | ------------------------------------------------ | ------------------------------------- |
-| `api-token`        | An account API token                             | `${{ secrets.CODACY_API_TOKEN }}`     |
-| `project-token`    | The project API token                            | `${{ secrets.CODACY_PROJECT_TOKEN }}` |
-| `coverage-reports` | Optional Comma separated list of reports to send | `''`                                  |
+| Setting            | Description                                                                            | Default value                         |
+| ------------------ | -------------------------------------------------------------------------------------- | ------------------------------------- |
+| `api-token`        | [Account API token](https://docs.codacy.com/codacy-api/api-tokens/#account-api-tokens) | `${{ secrets.CODACY_API_TOKEN }}`     |
+| `project-token`    | [Project API token](https://docs.codacy.com/codacy-api/api-tokens/#project-api-tokens) | `${{ secrets.CODACY_PROJECT_TOKEN }}` |
+| `coverage-reports` | Optional comma-separated list of reports to send                                       | `''`                                  |


### PR DESCRIPTION
Quick improvement so that users can easily find the instructions on how to obtain account and project API tokens.