### PR TITLE
feature: Download the the coverage script directly from the repository CY-4457

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -48,5 +48,5 @@ runs:
         if [ -n "${{ inputs.api-token }}" ]; then auth="--api-token ${{ inputs.api-token }} --organization-provider $ORGANIZATION_PROVIDER --username $OWNER_NAME --project-name $REPOSITORY_NAME"; fi
         if [ -n "${{ inputs.project-token }}" ]; then auth="--project-token ${{ inputs.project-token }}"; fi
 
-        bash <(curl -Ls https://coverage.codacy.com/get.sh) report $auth $params --partial &&\
-        bash <(curl -Ls https://coverage.codacy.com/get.sh) final $auth
+        bash <(curl -Ls https://raw.githubusercontent.com/codacy/codacy-coverage-reporter/master/get.sh) report $auth $params --partial &&\
+        bash <(curl -Ls https://raw.githubusercontent.com/codacy/codacy-coverage-reporter/master/get.sh) final $auth


### PR DESCRIPTION
Tackles #44 

* The script is hosted on the GitHub repo
* The script checks the checksum of the downloaded binary from artifacts.codacy.com