### PR TITLE
Add force-commit-sha input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -67,5 +67,5 @@ runs:
         if [ -n "${{ inputs.language }}" ]; then lang="--language ${{ inputs.language }}"; else lang=""; fi
         if [ -n '${{ inputs.force-commit-sha }}' ]; then force_commit="--commit-uuid '${{ inputs.force-commit-sha }}'"; else force_commit=""; fi
 
-        bash <(curl -Ls https://coverage.codacy.com/get.sh) report $lang $force_parser $auth $params --partial &&\
+        bash <(curl -Ls https://coverage.codacy.com/get.sh) report $lang $force_parser $force_commit $auth $params --partial &&\
         bash <(curl -Ls https://coverage.codacy.com/get.sh) final $auth

--- a/action.yml
+++ b/action.yml
@@ -68,4 +68,4 @@ runs:
         if [ -n '${{ inputs.force-commit-sha }}' ]; then force_commit="--commit-uuid '${{ inputs.force-commit-sha }}'"; else force_commit=""; fi
 
         bash <(curl -Ls https://coverage.codacy.com/get.sh) report $lang $force_parser $force_commit $auth $params --partial &&\
-        bash <(curl -Ls https://coverage.codacy.com/get.sh) final $auth
+        bash <(curl -Ls https://coverage.codacy.com/get.sh) final $force_commit $auth

--- a/action.yml
+++ b/action.yml
@@ -65,7 +65,7 @@ runs:
         if [ -n "${{ inputs.project-token }}" ]; then auth="--project-token ${{ inputs.project-token }}"; fi
         if [ -n "${{ inputs.force-coverage-parser }}" ]; then force_parser="--force-coverage-parser ${{ inputs.force-coverage-parser }}"; else force_parser=""; fi
         if [ -n "${{ inputs.language }}" ]; then lang="--language ${{ inputs.language }}"; else lang=""; fi
-        if [ -n '${{ inputs.force-commit-sha }}' ]; then force_commit="--commit-uuid '${{ inputs.force-commit-sha }}'"; else force_commit=""; fi
+        if [ -n "${{ inputs.force-commit-sha }}" ]; then force_commit="--commit-uuid ${{ inputs.force-commit-sha }}"; else force_commit=""; fi
 
         bash <(curl -Ls https://coverage.codacy.com/get.sh) report $lang $force_parser $force_commit $auth $params --partial &&\
         bash <(curl -Ls https://coverage.codacy.com/get.sh) final $force_commit $auth

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,9 @@ inputs:
   force-coverage-parser:
     description: 'Optionally force using a specific coverage report parser'
     required: false
+  force-commit-sha:
+    description: 'Optionally force commit associated to the coverage data'
+    required: false
   coverage-reporter-version:
     description: 'Optionally force using a specific coverage reporter version'
     required: false
@@ -62,6 +65,7 @@ runs:
         if [ -n "${{ inputs.project-token }}" ]; then auth="--project-token ${{ inputs.project-token }}"; fi
         if [ -n "${{ inputs.force-coverage-parser }}" ]; then force_parser="--force-coverage-parser ${{ inputs.force-coverage-parser }}"; else force_parser=""; fi
         if [ -n "${{ inputs.language }}" ]; then lang="--language ${{ inputs.language }}"; else lang=""; fi
+        if [ -n '${{ inputs.force-commit-sha }}' ]; then force_commit="--commit-uuid '${{ inputs.force-commit-sha }}'"; else force_commit=""; fi
 
         bash <(curl -Ls https://coverage.codacy.com/get.sh) report $lang $force_parser $auth $params --partial &&\
         bash <(curl -Ls https://coverage.codacy.com/get.sh) final $auth


### PR DESCRIPTION
Simple PR adding a `force-commit-sha` input.

While the workaround proposed [there](https://github.com/codacy/codacy-coverage-reporter-action/issues/67#issuecomment-1746608577) (=relying on the CLI directly) actually works when you have to deal with `workflow_run` executions, it has at least one major downside.
In case I want to keep the CLI version up to date, I need to either 
 - pin the version and **manually** update it. _While dependabot is able to automatically detect a GitHub action_
 - always use the latest version but it would imply that builds won't be repeatable. _A re-run may use a different version, which would decrease debugging capability_

Also, `workflow_run` seems the most secure/reliable way to deal with forked PR, but as stated on #78 the CLI uploader doesn't correctly handle that case. So adding the input would bring a nice workaround for issues like #33, #67 or #69 for instance.

Another way to cover the case would be to update the `GitHubActionProvider` from the CLI uploader directly (like did there https://github.com/codacy/codacy-coverage-reporter/pull/492), in order to manage `workflow_run` events, but I guess it would require way more than just the few lines added there.

Feel free to suggest any updates (input name/description, etc).