### PR TITLE
Update version to last release (2024-05-27)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ To upload coverage to Codacy using the GitHub Action using default settings:
         steps:
           - uses: actions/checkout@v2
           - name: Run codacy-coverage-reporter
-            uses: codacy/codacy-coverage-reporter-action@v1
+            uses: codacy/codacy-coverage-reporter-action@v1.3.0
             with:
               project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
               # or


### PR DESCRIPTION
Related issue [codacy-coverage-reporter/issues/502](https://github.com/codacy/codacy-coverage-reporter/issues/502 "[TCE-969] Pull request and push are failed: project or account API token not found")

[TCE-969]: https://codacy.atlassian.net/browse/TCE-969?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ